### PR TITLE
Changed secrets to env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 tfout
 tfplan
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # cnp_terrafrom_templates
+
 Terraform templates for automating deployment of Cloud Network Protection
 
-#Prior to deploying this template, please request that the vSMS AMI be shared
-#with your AWS account.  You will need to provide your AWS account number.
+Prior to deploying this template, please request that the vSMS AMI be shared with your AWS account.  You will need to provide your AWS account number.
+
+Pass in the following environment variables:
+* TF_VAR_key_pair
+* TF_VAR_private_key_file
+* TF_VAR_sms_api_key
+* AWS_ACCESS_KEY_ID
+* AWS_SECRET_ACCESS_KEY
+
+```
 cnp_demo:
 	Internet VPC
 		Public Subnet
@@ -25,5 +34,4 @@ cnp_demo:
 		Internet VPC attachment to Public Connection subnet
     Workload VPC attachment to workload subnet
     Inspection VPC attachment to Inspection Connection subnet
-
-
+```

--- a/cnp_demo/CNPDemo.auto.tfvars
+++ b/cnp_demo/CNPDemo.auto.tfvars
@@ -9,14 +9,6 @@ unique_id = "CNPDEMO"
 #All Ubuntu Server AMIs per region
 region = "us-east-2" # us-east2 (original)
 #region = "us-east-1"
-#The name of the keypair you will use to connect to the instances.  This keypair must exist in the region
-key_pair = "<key_pair_name_in_aws>"
-#key_pair = "Demo"
-#Provide the full path to your private key file that corresponds to the keypair you specified above.
-private_key_file = "<path_to_your_private_key_file>" 
-#private_key_file = "~/code/terraform/Demo.pem"
-#Provide the SMS API key from the wiki page that describes how to use this Terraform template
-sms_api_key = ""
 
 #
 #-------DO NOT CHANGE ANY MORE UNLESS YOU KNOW WHAT YOU ARE DOING------

--- a/cnp_demo/variables.tf
+++ b/cnp_demo/variables.tf
@@ -1,13 +1,11 @@
-variable "unique_id" {
-  type = string
-}
-
 variable "key_pair" {
-  type = string
+  type        = string
+  description = "The name of the keypair you will use to connect to the instances.  This keypair must exist in the region"
 }
 
 variable "private_key_file" {
-  type = string
+  type        = string
+  description = "Provide the full path to your private key file that corresponds to the keypair you specified above."
 }
 
 variable "region" {
@@ -16,7 +14,8 @@ variable "region" {
 }
 
 variable "sms_api_key" {
-  type = string
+  type        = string
+  description = "Provide the SMS API key from the wiki page that describes how to use this Terraform template"
 }
 
 variable "sms_private_ip" {

--- a/cnp_vpn_demo/CNPDemo.auto.tfvars
+++ b/cnp_vpn_demo/CNPDemo.auto.tfvars
@@ -9,8 +9,6 @@ unique_id = "BHDEMO"
 #All Ubuntu Server AMIs per region
 region = "us-east-2"
 
-key_pair = "cnp_demo_keys"
-
 customer_gw_ip = "4.14.202.50"
 
 #All CNP AMIs per region


### PR DESCRIPTION
Enables users to specify sensitive information (e.g SMS API key) as an environment variable. 

Note that existing secrets should be removed from git's history.